### PR TITLE
Do not remove spaces while reading files

### DIFF
--- a/markup_tag_evaluation/evaluate_markup_tags.py
+++ b/markup_tag_evaluation/evaluate_markup_tags.py
@@ -33,7 +33,7 @@ def parse_args():
 
 def read_text(path: str) -> List[str]:
     with open(path, "r", encoding="utf-8") as f:
-        return [" ".join(s.split()) for s in f]
+        return [s for s in f]
 
 
 def main() -> None:


### PR DESCRIPTION
Normalizing spaces with `" ".join(s.split())` can affect the reference and hypothesis differently, e.g.:
```
>>> ref = "A <b> bold</b> word."
>>> hyp = "A  <b>bold</b> word."
>>> " ".join(ref.split())
'A <b> bold</b> word.'
>>> " ".join(hyp.split())
'A <b>bold</b> word.'
>>> len(" ".join(ref.split()))
20
>>> len(" ".join(hyp.split()))
19
```

I think it was a mistake to normalize spaces at all, and only didn't cause issues on very clean data.